### PR TITLE
Add __serialize/__unserialize

### DIFF
--- a/lib/Horde/Imap/Client/Base.php
+++ b/lib/Horde/Imap/Client/Base.php
@@ -364,20 +364,31 @@ implements Serializable, SplObserver
      */
     public function serialize()
     {
-        return serialize(array(
-            'i' => $this->_init,
-            'p' => $this->_params,
-            'v' => self::VERSION
-        ));
+        return serialize($this->__serialize());
     }
 
     /**
      */
     public function unserialize($data)
     {
-        $data = @unserialize($data);
-        if (!is_array($data) ||
-            !isset($data['v']) ||
+        $this->__unserialize(@unserialize($data));
+    }
+
+    /**
+     * @return array
+     */
+    public function __serialize()
+    {
+        return array(
+            'i' => $this->_init,
+            'p' => $this->_params,
+            'v' => self::VERSION
+        );
+    }
+
+    public function __unserialize(array $data)
+    {
+        if (!isset($data['v']) ||
             ($data['v'] != self::VERSION)) {
             throw new Exception('Cache version change');
         }

--- a/lib/Horde/Imap/Client/Cache/Backend.php
+++ b/lib/Horde/Imap/Client/Cache/Backend.php
@@ -151,14 +151,27 @@ abstract class Horde_Imap_Client_Cache_Backend implements Serializable
      */
     public function serialize()
     {
-        return serialize($this->_params);
+        return serialize($this->__serialize());
     }
 
     /**
      */
     public function unserialize($data)
     {
-        $this->_params = unserialize($data);
+        $this->__unserialize(unserialize($data));
+    }
+
+    /**
+     * @return array
+     */
+    public function __serialize()
+    {
+        return $this->_params;
+    }
+
+    public function __unserialize(array $data)
+    {
+        $this->_params = $data;
         $this->_initOb();
     }
 

--- a/lib/Horde/Imap/Client/Cache/Backend/Cache.php
+++ b/lib/Horde/Imap/Client/Cache/Backend/Cache.php
@@ -503,4 +503,13 @@ extends Horde_Imap_Client_Cache_Backend
         return parent::serialize();
     }
 
+    /**
+     * @return array
+     */
+    public function __serialize()
+    {
+        $this->save();
+        return parent::__serialize();
+    }
+
 }

--- a/lib/Horde/Imap/Client/Data/Acl.php
+++ b/lib/Horde/Imap/Client/Data/Acl.php
@@ -166,4 +166,19 @@ class Horde_Imap_Client_Data_Acl extends Horde_Imap_Client_Data_AclCommon implem
         $this->_rights = json_decode($data);
     }
 
+    /**
+     * @return array
+     */
+    public function __serialize()
+    {
+        return array(
+            'rights' => $this->_rights
+        );
+    }
+
+    public function __unserialize(array $data)
+    {
+        $this->_rights = $data['rights'];
+    }
+
 }

--- a/lib/Horde/Imap/Client/Data/AclRights.php
+++ b/lib/Horde/Imap/Client/Data/AclRights.php
@@ -201,17 +201,30 @@ class Horde_Imap_Client_Data_AclRights extends Horde_Imap_Client_Data_AclCommon 
      */
     public function serialize()
     {
-        return json_encode(array(
-            $this->_required,
-            $this->_optional
-        ));
+        return json_encode($this->__serialize());
     }
 
     /**
      */
     public function unserialize($data)
     {
-        list($this->_required, $this->_optional) = json_decode($data);
+        $this->__unserialize(json_decode($data, true));
+    }
+
+    /**
+     * @return array
+     */
+    public function __serialize()
+    {
+        return array(
+            $this->_required,
+            $this->_optional,
+        );
+    }
+
+    public function __unserialize(array $data)
+    {
+        list($this->_required, $this->_optional) = $data;
     }
 
 }

--- a/lib/Horde/Imap/Client/Data/Capability.php
+++ b/lib/Horde/Imap/Client/Data/Capability.php
@@ -204,14 +204,27 @@ implements Serializable, SplSubject
      */
     public function serialize()
     {
-        return json_encode($this->_data);
+        return json_encode($this->__serialize());
     }
 
     /**
      */
     public function unserialize($data)
     {
-        $this->_data = json_decode($data, true);
+        $this->__unserialize(json_decode($data, true));
+    }
+
+    /**
+     * @return array
+     */
+    public function __serialize()
+    {
+        return $this->_data;
+    }
+
+    public function __unserialize(array $data)
+    {
+        $this->_data = $data;
     }
 
 }

--- a/lib/Horde/Imap/Client/Data/Envelope.php
+++ b/lib/Horde/Imap/Client/Data/Envelope.php
@@ -205,10 +205,7 @@ class Horde_Imap_Client_Data_Envelope implements Serializable
      */
     public function serialize()
     {
-        return serialize(array(
-            'd' => $this->_data,
-            'v' => self::VERSION
-        ));
+        return serialize($this->__serialize());
     }
 
     /**
@@ -216,7 +213,23 @@ class Horde_Imap_Client_Data_Envelope implements Serializable
     public function unserialize($data)
     {
         $data = @unserialize($data);
-        if (empty($data['v']) || ($data['v'] != self::VERSION)) {
+        $this->__unserialize($data);
+    }
+
+    /**
+     * @return array
+     */
+    public function __serialize()
+    {
+        return array(
+            'd' => $this->_data,
+            'v' => self::VERSION,
+        );
+    }
+
+    public function __unserialize(array $data)
+    {
+        if (empty($data['v']) || $data['v'] != self::VERSION) {
             throw new Exception('Cache version change');
         }
 

--- a/lib/Horde/Imap/Client/Data/Namespace.php
+++ b/lib/Horde/Imap/Client/Data/Namespace.php
@@ -130,14 +130,27 @@ class Horde_Imap_Client_Data_Namespace implements Serializable
      */
     public function serialize()
     {
-        return json_encode($this->_data);
+        return json_encode($this->__serialize());
     }
 
     /**
      */
     public function unserialize($data)
     {
-        $this->_data = json_decode($data, true);
+        $this->__unserialize(json_decode($data, true));
+    }
+
+    /**
+     * @return array
+     */
+    public function __serialize()
+    {
+        return $this->_data;
+    }
+
+    public function __unserialize(array $data)
+    {
+        $this->_data = $data;
     }
 
 }

--- a/lib/Horde/Imap/Client/Data/SearchCharset.php
+++ b/lib/Horde/Imap/Client/Data/SearchCharset.php
@@ -168,14 +168,27 @@ implements Serializable, SplSubject
      */
     public function serialize()
     {
-        return json_encode($this->_charsets);
+        return json_encode($this->__serialize());
     }
 
     /**
      */
     public function unserialize($data)
     {
-        $this->_charsets = json_decode($data, true);
+        $this->__unserialize(json_decode($data, true));
+    }
+
+    /**
+     * @return array
+     */
+    public function __serialize()
+    {
+        return $this->_charsets;
+    }
+
+    public function __unserialize(array $data)
+    {
+        $this->_charsets = $data;
     }
 
 }

--- a/lib/Horde/Imap/Client/Data/SearchCharset/Utf8.php
+++ b/lib/Horde/Imap/Client/Data/SearchCharset/Utf8.php
@@ -63,4 +63,16 @@ extends Horde_Imap_Client_Data_SearchCharset
     {
     }
 
+    /**
+     * @return array
+     */
+    public function __serialize()
+    {
+        return array();
+    }
+
+    public function __unserialize(array $data)
+    {
+    }
+
 }

--- a/lib/Horde/Imap/Client/Data/Thread.php
+++ b/lib/Horde/Imap/Client/Data/Thread.php
@@ -183,17 +183,30 @@ class Horde_Imap_Client_Data_Thread implements Countable, Serializable
      */
     public function serialize()
     {
-        return json_encode(array(
-            $this->_thread,
-            $this->_type
-        ));
+        return json_encode($this->__serialize());
     }
 
     /**
      */
     public function unserialize($data)
     {
-        list($this->_thread, $this->_type) = json_decode($data, true);
+        $this->__unserialize(json_decode($data, true));
+    }
+
+    /**
+     * @return array
+     */
+    public function __serialize()
+    {
+        return array(
+            $this->_thread,
+            $this->_type,
+        );
+    }
+
+    public function __unserialize(array $data)
+    {
+        list($this->_thread, $this->_type) = $data;
     }
 
     /* Protected methods. */

--- a/lib/Horde/Imap/Client/Ids.php
+++ b/lib/Horde/Imap/Client/Ids.php
@@ -441,6 +441,21 @@ class Horde_Imap_Client_Ids implements Countable, Iterator, Serializable
      */
     public function serialize()
     {
+        return serialize($this->__serialize());
+    }
+
+    /**
+     */
+    public function unserialize($data)
+    {
+        $this->__unserialize(@unserialize($data));
+    }
+
+    /**
+     * @return array
+     */
+    public function __serialize()
+    {
         $save = array();
 
         if ($this->duplicates) {
@@ -456,44 +471,40 @@ class Horde_Imap_Client_Ids implements Countable, Iterator, Serializable
         }
 
         switch ($this->_ids) {
-        case self::ALL:
-            $save['a'] = true;
-            break;
+            case self::ALL:
+                $save['a'] = true;
+                break;
 
-        case self::LARGEST:
-            $save['l'] = true;
-            break;
+            case self::LARGEST:
+                $save['l'] = true;
+                break;
 
-        case self::SEARCH_RES:
-            $save['sr'] = true;
-            break;
+            case self::SEARCH_RES:
+                $save['sr'] = true;
+                break;
 
-        default:
-            $save['i'] = strval($this);
-            break;
+            default:
+                $save['i'] = strval($this);
+                break;
         }
 
-        return serialize($save);
+        return $save;
     }
 
-    /**
-     */
-    public function unserialize($data)
+    public function __unserialize(array $data)
     {
-        $save = @unserialize($data);
+        $this->duplicates = !empty($data['d']);
+        $this->_sequence = !empty($data['s']);
+        $this->_sorted = !empty($data['is']);
 
-        $this->duplicates = !empty($save['d']);
-        $this->_sequence = !empty($save['s']);
-        $this->_sorted = !empty($save['is']);
-
-        if (isset($save['a'])) {
+        if (isset($data['a'])) {
             $this->_ids = self::ALL;
-        } elseif (isset($save['l'])) {
+        } elseif (isset($data['l'])) {
             $this->_ids = self::LARGEST;
-        } elseif (isset($save['sr'])) {
+        } elseif (isset($data['sr'])) {
             $this->_ids = self::SEARCH_RES;
-        } elseif (isset($save['i'])) {
-            $this->add($save['i']);
+        } elseif (isset($data['i'])) {
+            $this->add($data['i']);
         }
     }
 

--- a/lib/Horde/Imap/Client/Ids/Map.php
+++ b/lib/Horde/Imap/Client/Ids/Map.php
@@ -218,21 +218,32 @@ class Horde_Imap_Client_Ids_Map implements Countable, IteratorAggregate, Seriali
      */
     public function serialize()
     {
-        /* Sort before storing; provides more compressible representation. */
-        $this->sort();
-
-        return json_encode(array(
-            strval(new Horde_Imap_Client_Ids(array_keys($this->_ids))),
-            strval(new Horde_Imap_Client_Ids(array_values($this->_ids)))
-        ));
+        return json_encode($this->__serialize());
     }
 
     /**
      */
     public function unserialize($data)
     {
-        $data = json_decode($data, true);
+        $this->__unserialize(json_decode($data, true));
+    }
 
+    /**
+     * @return array
+     */
+    public function __serialize()
+    {
+        /* Sort before storing; provides more compressible representation. */
+        $this->sort();
+
+        return array(
+            (string)new Horde_Imap_Client_Ids(array_keys($this->_ids)),
+            (string)new Horde_Imap_Client_Ids(array_values($this->_ids)),
+        );
+    }
+
+    public function __unserialize(array $data)
+    {
         $keys = new Horde_Imap_Client_Ids($data[0]);
         $vals = new Horde_Imap_Client_Ids($data[1]);
         $this->_ids = array_combine($keys->ids, $vals->ids);

--- a/lib/Horde/Imap/Client/Mailbox.php
+++ b/lib/Horde/Imap/Client/Mailbox.php
@@ -134,14 +134,27 @@ class Horde_Imap_Client_Mailbox implements Serializable
      */
     public function serialize()
     {
-        return json_encode(array($this->_utf7imap, $this->_utf8));
+        return json_encode($this->__serialize());
     }
 
     /**
      */
     public function unserialize($data)
     {
-        list($this->_utf7imap, $this->_utf8) = json_decode($data, true);
+         $this->__unserialize(json_decode($data, true));
+    }
+
+    /**
+     * @return array
+     */
+    public function __serialize()
+    {
+        return array($this->_utf7imap, $this->_utf8);
+    }
+
+    public function __unserialize(array $data)
+    {
+        list($this->_utf7imap, $this->_utf8) = $data;
     }
 
 }

--- a/lib/Horde/Imap/Client/Search/Query.php
+++ b/lib/Horde/Imap/Client/Search/Query.php
@@ -866,17 +866,7 @@ class Horde_Imap_Client_Search_Query implements Serializable
      */
     public function serialize()
     {
-        $data = array(
-            // Serialized data ID.
-            self::VERSION,
-            $this->_search
-        );
-
-        if (!is_null($this->_charset)) {
-            $data[] = $this->_charset;
-        }
-
-        return serialize($data);
+        return serialize($this->__serialize());
     }
 
     /**
@@ -888,9 +878,29 @@ class Horde_Imap_Client_Search_Query implements Serializable
      */
     public function unserialize($data)
     {
-        $data = @unserialize($data);
-        if (!is_array($data) ||
-            !isset($data[0]) ||
+        $this->__unserialize(@unserialize($data));
+    }
+
+    /**
+     * @return array
+     */
+    public function __serialize()
+    {
+        $data = array(
+            self::VERSION,
+            $this->_search,
+        );
+
+        if ($this->_charset !== null) {
+            $data[] = $this->_charset;
+        }
+
+        return $data;
+    }
+
+    public function __unserialize(array $data)
+    {
+        if (!isset($data[0]) ||
             ($data[0] != self::VERSION)) {
             throw new Exception('Cache version change');
         }

--- a/lib/Horde/Imap/Client/Url.php
+++ b/lib/Horde/Imap/Client/Url.php
@@ -299,4 +299,19 @@ class Horde_Imap_Client_Url implements Serializable
         $this->_parse($data);
     }
 
+    /**
+     * @return array
+     */
+    public function __serialize()
+    {
+        return array(
+            (string)$this,
+        );
+    }
+
+    public function __unserialize(array $data)
+    {
+        $this->_parse($data[0]);
+    }
+
 }

--- a/lib/Horde/Imap/Client/Url/Base.php
+++ b/lib/Horde/Imap/Client/Url/Base.php
@@ -170,4 +170,19 @@ abstract class Horde_Imap_Client_Url_Base implements Serializable
         $this->_parse($data);
     }
 
+    /**
+     * @return array
+     */
+    public function __serialize()
+    {
+        return array(
+            (string)$this,
+        );
+    }
+
+    public function __unserialize(array $data)
+    {
+        $this->_parse($data[0]);
+    }
+
 }


### PR DESCRIPTION
> As of PHP 8.1.0, a class which implements Serializable without also implementing [__serialize()](https://www.php.net/manual/en/language.oop5.magic.php#object.serialize) and [__unserialize()](https://www.php.net/manual/en/language.oop5.magic.php#object.unserialize) will generate a deprecation warning.

This was more work than I want to admit. Yet this is fully untested.

Upstream PR: https://github.com/horde/Imap_Client/pull/21