### PR TITLE
Fix PHP 8.1 deprecation notice when passing null to Collator

### DIFF
--- a/lib/Horde/Imap/Client/Socket/ClientSort.php
+++ b/lib/Horde/Imap/Client/Socket/ClientSort.php
@@ -51,7 +51,7 @@ class Horde_Imap_Client_Socket_ClientSort
         $this->_socket = $socket;
 
         if (class_exists('Collator')) {
-            $this->_collator = new Collator(null);
+            $this->_collator = new Collator('');
         }
     }
 


### PR DESCRIPTION
```
PHP Deprecated:  Collator::__construct(): Passing null to parameter #1 ($locale) of type string is deprecated in /home/runner/work/Imap_Client/Imap_Client/lib/Horde/Imap/Client/Socket/ClientSort.php on line 54
```