### PR TITLE
Add read_timeout

### DIFF
--- a/lib/Horde/Imap/Client/Base.php
+++ b/lib/Horde/Imap/Client/Base.php
@@ -230,6 +230,8 @@ implements Serializable, SplObserver
      *     DEFAULT: false
      * - timeout: (integer)  Connection timeout, in seconds.
      *            DEFAULT: 30 seconds
+     * - read_timeout: (integer) Read timeout, in seconds.
+     *                 DEFAULT: 30 seconds
      * - username: (string) [REQUIRED] The username.
      * - authusername (string) The username used for SASL authentication.
      * 	 If specified this is the user name whose password is used
@@ -251,7 +253,8 @@ implements Serializable, SplObserver
             'context' => array(),
             'hostspec' => 'localhost',
             'secure' => false,
-            'timeout' => 30
+            'timeout' => 30,
+            'read_timeout' => 30,
         ), array_filter($params));
 
         if (!isset($params['port']) && strpos($params['hostspec'], 'unix://') !== 0) {

--- a/lib/Horde/Imap/Client/Socket.php
+++ b/lib/Horde/Imap/Client/Socket.php
@@ -598,7 +598,8 @@ class Horde_Imap_Client_Socket extends Horde_Imap_Client_Base
                 $this->getParam('context'),
                 array(
                     'debug' => $this->_debug,
-                    'debugliteral' => $this->getParam('debug_literal')
+                    'debugliteral' => $this->getParam('debug_literal'),
+                    'read_timeout' => $this->getParam('read_timeout'),
                 )
             );
         } catch (Horde\Socket\Client\Exception $e) {

--- a/lib/Horde/Imap/Client/Socket/Connection/Socket.php
+++ b/lib/Horde/Imap/Client/Socket/Connection/Socket.php
@@ -183,22 +183,50 @@ extends Horde_Imap_Client_Socket_Connection_Base
 
             $old_len = $literal_len;
 
-            while (($literal_len > 0) && !feof($this->_stream)) {
-                $in = fread($this->_stream, min($literal_len, 8192));
-                /* Only store in stream if this is something more than a
-                 * nominal number of bytes. */
-                if ($old_len > 256) {
-                    $token->addLiteralStream($in);
-                } else {
-                    $token->add($in);
-                }
+            try {
+                stream_set_blocking($this->_stream, false);
 
-                if (!empty($this->_params['debugliteral'])) {
-                    $this->_params['debug']->raw($in);
-                }
+                while (($literal_len > 0) && !feof($this->_stream)) {
+                    $in = fread($this->_stream, min($literal_len, 8192));
 
-                $got_data = true;
-                $literal_len -= strlen($in);
+                    if (empty($in)) {
+                        if (! isset($read_start)) {
+                            $read_start = microtime(true);
+                        }
+
+                        $read_now = microtime(true);
+                        $t_read = $read_now - $read_start;
+                        if ($t_read > $this->_params['read_timeout']) {
+                            $this->_params['debug']->info(sprintf('ERROR: read timeout. No data received for %d seconds.', $this->_params['read_timeout']));
+
+                            throw new Horde_Imap_Client_Exception(
+                                Horde_Imap_Client_Translation::r("Read timeout."),
+                                Horde_Imap_Client_Exception::DISCONNECT
+                            );
+                        }
+
+                        continue;
+                    }
+
+                    $read_start = null;
+
+                    /* Only store in stream if this is something more than a
+                     * nominal number of bytes. */
+                    if ($old_len > 256) {
+                        $token->addLiteralStream($in);
+                    } else {
+                        $token->add($in);
+                    }
+
+                    if (!empty($this->_params['debugliteral'])) {
+                        $this->_params['debug']->raw($in);
+                    }
+
+                    $got_data = true;
+                    $literal_len -= strlen($in);
+                }
+            } finally {
+                stream_set_blocking($this->_stream, true);
             }
 
             $literal_len = null;


### PR DESCRIPTION
`feof` hangs indefinitely when the stream is in blocking mode and the client disconnects - https://github.com/php/php-src/issues/10495

Temporarily making it non-blocking, with a read timeout, resolves the issue.