### PR TITLE
Improve read_timeout handling

### DIFF
--- a/lib/Horde/Imap/Client/Base.php
+++ b/lib/Horde/Imap/Client/Base.php
@@ -231,7 +231,7 @@ implements Serializable, SplObserver
      * - timeout: (integer)  Connection timeout, in seconds.
      *            DEFAULT: 30 seconds
      * - read_timeout: (integer) Read timeout, in seconds.
-     *                 DEFAULT: 30 seconds
+     *                 DEFAULT: 120 seconds
      * - username: (string) [REQUIRED] The username.
      * - authusername (string) The username used for SASL authentication.
      * 	 If specified this is the user name whose password is used
@@ -254,7 +254,7 @@ implements Serializable, SplObserver
             'hostspec' => 'localhost',
             'secure' => false,
             'timeout' => 30,
-            'read_timeout' => 30,
+            'read_timeout' => 120,
         ), array_filter($params));
 
         if (!isset($params['port']) && strpos($params['hostspec'], 'unix://') !== 0) {

--- a/lib/Horde/Imap/Client/Exception.php
+++ b/lib/Horde/Imap/Client/Exception.php
@@ -80,6 +80,11 @@ class Horde_Imap_Client_Exception extends Horde_Exception_Wrapped
     const SERVER_READERROR = 12;
 
     /**
+     * Thrown if read timeout occurs.
+     */
+    const SERVER_READTIMEOUT = 28;
+
+    /**
      * Thrown if write error in server interaction.
      */
     const SERVER_WRITEERROR = 16;

--- a/lib/Horde/Imap/Client/Socket/Connection/Socket.php
+++ b/lib/Horde/Imap/Client/Socket/Connection/Socket.php
@@ -196,12 +196,12 @@ extends Horde_Imap_Client_Socket_Connection_Base
 
                         $read_now = microtime(true);
                         $t_read = $read_now - $read_start;
-                        if ($t_read > $this->_params['read_timeout']) {
+                        if ($t_read > $this->_params['timeout']) {
                             $this->_params['debug']->info(sprintf('ERROR: read timeout. No data received for %d seconds.', $this->_params['read_timeout']));
 
                             throw new Horde_Imap_Client_Exception(
                                 Horde_Imap_Client_Translation::r("Read timeout."),
-                                Horde_Imap_Client_Exception::DISCONNECT
+                                Horde_Imap_Client_Exception::SERVER_READTIMEOUT
                             );
                         }
 
@@ -237,10 +237,10 @@ extends Horde_Imap_Client_Socket_Connection_Base
         } while (true);
 
         if (!$got_data) {
-            $this->_params['debug']->info('ERROR: read/timeout error.');
+            $this->_params['debug']->info('ERROR: read timeout error.');
             throw new Horde_Imap_Client_Exception(
                 Horde_Imap_Client_Translation::r("Error when communicating with the mail server."),
-                Horde_Imap_Client_Exception::SERVER_READERROR
+                Horde_Imap_Client_Exception::SERVER_READTIMEOUT
             );
         }
 


### PR DESCRIPTION
`_sendCmdChunk` can loop indefinitely on a read/timeout error