### PR TITLE
Fix imap date on POP3

### DIFF
--- a/lib/Horde/Imap/Client/Socket/Pop3.php
+++ b/lib/Horde/Imap/Client/Socket/Pop3.php
@@ -998,7 +998,7 @@ class Horde_Imap_Client_Socket_Pop3 extends Horde_Imap_Client_Base
             case Horde_Imap_Client::FETCH_IMAPDATE:
                 foreach ($seq_ids as $id) {
                     $tmp = $this->_pop3Cache('hdrob', $id);
-                    $results->get($lookup[$id])->setImapDate($tmp['Date']);
+                    $results->get($lookup[$id])->setImapDate((string) $tmp['Date']);
                 }
                 break;
 


### PR DESCRIPTION
`$tmp['Date']` is an instance of `Horde_Mime_Headers_Date` which results in an incorrect type passed to `setImapDate()`:
```php
/**
 * Set IMAP internal date.
 *
 * @param mixed $date  Either a Horde_Imap_Client_DateTime object or a date string.
 */
public function setImapDate($date)
{
    $this->_data[Horde_Imap_Client::FETCH_IMAPDATE] = is_object($date)
        ? $date
        : new Horde_Imap_Client_DateTime($date);
}
```

Call `getImapDate()` on a POP3 socket using a fetch query of the below to replicate:
```php
$query = new Horde_Imap_Client_Fetch_Query;
$query->imapDate();
```