### PR TITLE
fix: close internal tokenizer stream

### DIFF
--- a/lib/Horde/Imap/Client/Tokenize.php
+++ b/lib/Horde/Imap/Client/Tokenize.php
@@ -93,6 +93,10 @@ class Horde_Imap_Client_Tokenize implements Iterator
         }
     }
 
+    public function __destruct() {
+        $this->_stream->close();
+    }
+
     /**
      */
     public function __clone()


### PR DESCRIPTION
The object is cleaned up by PHP but the (temp) stream remains open thus leaking a lot of memory. Potentially thousands of tokenizer instances are created when syncing large mailboxes which causes significant memory leaks.

Requires https://github.com/bytestream/Stream/pull/5