### PR TITLE
fix: use timeout instead of read_timeout for debug message

### DIFF
--- a/lib/Horde/Imap/Client/Socket/Connection/Socket.php
+++ b/lib/Horde/Imap/Client/Socket/Connection/Socket.php
@@ -197,7 +197,7 @@ extends Horde_Imap_Client_Socket_Connection_Base
                         $read_now = microtime(true);
                         $t_read = $read_now - $read_start;
                         if ($t_read > $this->_params['timeout']) {
-                            $this->_params['debug']->info(sprintf('ERROR: read timeout. No data received for %d seconds.', $this->_params['read_timeout']));
+                            $this->_params['debug']->info(sprintf('ERROR: read timeout. No data received for %d seconds.', $this->_params['timeout']));
 
                             throw new Horde_Imap_Client_Exception(
                                 Horde_Imap_Client_Translation::r("Read timeout."),


### PR DESCRIPTION
Hi :wave:

I'm debugging an issue where search operations are timing out and have stepped through the code. I'm not entirely sure if I understood it correctly, but it seems like we should be using the general timeout for the debug message as well, instead of the read_timeout.