### PR TITLE
fix: don't store exception for temporary read timeouts

### DIFF
--- a/lib/Horde/Imap/Client/Socket.php
+++ b/lib/Horde/Imap/Client/Socket.php
@@ -4340,13 +4340,15 @@ class Horde_Imap_Client_Socket extends Horde_Imap_Client_Base
                         $this->_temp['logout'] = true;
                         $this->logout();
                         throw $e;
-                }
 
-                /* For all other issues, catch and store exception; don't
-                 * throw until all input is read since we need to clear
-                 * incoming queue. (For now, only store first exception.) */
-                if (is_null($exception)) {
-                    $exception = $e;
+                    default:
+                        /* For all other issues, catch and store exception; don't
+                         * throw until all input is read since we need to clear
+                         * incoming queue. (For now, only store first exception.) */
+                        if (is_null($exception)) {
+                            $exception = $e;
+                        }
+
                 }
 
                 if (($e instanceof Horde_Imap_Client_Exception_ServerResponse) &&


### PR DESCRIPTION
Hey :wave: 

Marking the PR as draft to discuss the approach.
I'm still checking if adding some unit tests is possible.

---

A Nextcloud Mail user ran into trouble when searching for messages in larger mailboxes. Sometimes, the search would error out even though it actually succeeded.

Reproducing this issue was tricky, but I managed to see it with a timeout of 1 second and a mailbox with around 6000 messages. Dovecot seems to cache some data, so often the second or third search would work fine without hitting the bug.

With debugging on, I saw this response from the IMAP server:

```
C: 3 UID SEARCH RETURN (ALL COUNT) BODY Test
>> ERROR: read timeout error.
>> ERROR: read timeout error.
>> ERROR: read timeout error.
S: * OK Searched 10% of the mailbox, ETA 1:26
>> ERROR: read timeout error.
>> ERROR: read timeout error.
S: * OK Searched 41% of the mailbox, ETA 0:28
>> ERROR: read timeout error.
```

- When the server is busy searching, `$in` can be `false`, which throws an exception.[^1][^2]
- This exception gets stored as `$exception`, even if we haven't hit the read timeout yet.[^3]
- Later, this stored exception gets rethrown, even if the search was successful and we have valid results.[^4]

Let's not store the exception if we're still within the read timeout. This way, we won't rethrow exceptions unnecessarily when everything actually worked out fine.

[^1]: https://github.com/bytestream/Imap_Client/blob/f66eeb655e2299e35cd79b8f5c597c15b9637333/lib/Horde/Imap/Client/Socket/Connection/Socket.php#L156
[^2]: https://github.com/bytestream/Imap_Client/blob/f66eeb655e2299e35cd79b8f5c597c15b9637333/lib/Horde/Imap/Client/Socket/Connection/Socket.php#L241-L244
[^3]: https://github.com/bytestream/Imap_Client/blob/f66eeb655e2299e35cd79b8f5c597c15b9637333/lib/Horde/Imap/Client/Socket.php#L4325-L4350
[^4]: https://github.com/bytestream/Imap_Client/blob/f66eeb655e2299e35cd79b8f5c597c15b9637333/lib/Horde/Imap/Client/Socket.php#L4359-L4361