### PR TITLE
fix: do not compare with empty for highestseq

### DIFF
--- a/lib/Horde/Imap/Client/Base.php
+++ b/lib/Horde/Imap/Client/Base.php
@@ -4066,7 +4066,7 @@ implements Serializable, SplObserver
             $out[$sync_map[$val]] = $status[$val];
         }
 
-        return array_filter($out);
+        return $out;
     }
 
     /**

--- a/lib/Horde/Imap/Client/Base.php
+++ b/lib/Horde/Imap/Client/Base.php
@@ -4053,7 +4053,7 @@ implements Serializable, SplObserver
         );
 
         $fields = array('uidnext', 'uidvalidity');
-        if (empty($status['highestmodseq'])) {
+        if (!isset($status['highestmodseq'])) {
             $fields[] = 'messages';
         } else {
             $fields[] = 'highestmodseq';


### PR DESCRIPTION
### Case
https://github.com/nextcloud/mail/issues/10581

### Cause
- empty() was used to find if array element 'highestmodseq' exists, this works in most cases except for when 'highestmodseq' = 0
- also the use of array_filter($out); caused values for 'highestmodseq' and 'messages' to be filtered out, when 0 is a valid value

### Correction
- Use isset() instead 
- Do not use array_filter($out) on return