### PR TITLE
Chunking for vanished command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ run-tests.log
 /.phpunit.result.cache
 /composer.lock
 /vendor
+
+# PhpStorm
+/.idea

--- a/lib/Horde/Imap/Client/Socket.php
+++ b/lib/Horde/Imap/Client/Socket.php
@@ -3567,21 +3567,23 @@ class Horde_Imap_Client_Socket extends Horde_Imap_Client_Base
         return $ret;
     }
 
-    /**
-     */
     protected function _vanished($modseq, Horde_Imap_Client_Ids $ids)
     {
-        $pipeline = $this->_pipeline(
-            $this->_command('UID FETCH')->add(array(
-                strval($ids),
-                'UID',
-                new Horde_Imap_Client_Data_Format_List(array(
-                    'VANISHED',
-                    'CHANGEDSINCE',
-                    new Horde_Imap_Client_Data_Format_Number($modseq)
-                ))
-            ))
-        );
+        // Unlike _fetchCmd(), sequence IDs are rejected before reaching here, so we always issue UID FETCH.
+
+        $modifiers = new Horde_Imap_Client_Data_Format_List([
+            'VANISHED',
+            'CHANGEDSINCE',
+            new Horde_Imap_Client_Data_Format_Number($modseq)
+        ]);
+
+        $pipeline = $this->_pipeline();
+
+        foreach ($ids->split($this->_capability()->cmdlength) as $val) {
+            $cmd = $this->_command('UID FETCH')->add([$val, 'UID', $modifiers]);
+            $pipeline->add($cmd);
+        }
+
         $pipeline->data['vanished'] = $this->getIdsOb();
 
         return $this->_sendCmd($pipeline)->data['vanished'];

--- a/test/Horde/Imap/Client/SocketTest.php
+++ b/test/Horde/Imap/Client/SocketTest.php
@@ -354,4 +354,22 @@ class Horde_Imap_Client_SocketTest extends \PHPUnit\Framework\TestCase
         $this->assertNotNull($env->to);
     }
 
+    public function testVanishedCommand()
+    {
+        // 200 non-consecutive 4-digit UIDs, fits in one 2000-octet command.
+        $ids = new Horde_Imap_Client_Ids(range(1001, 1399, 2));
+        $this->test_ob->doVanishedPipeline(12345, $ids);
+
+        $this->assertCount(1, $this->test_ob->capturedPipeline);
+    }
+
+    public function testVanishedCommandChunks()
+    {
+        // 500 non-consecutive 4-digit UIDs, exceeds the 2000-octet limit.
+        $ids = new Horde_Imap_Client_Ids(range(1001, 1999, 2));
+        $this->test_ob->doVanishedPipeline(12345, $ids);
+
+        $this->assertGreaterThan(1, count($this->test_ob->capturedPipeline));
+    }
+
 }

--- a/test/Horde/Imap/Client/Stub/Socket.php
+++ b/test/Horde/Imap/Client/Stub/Socket.php
@@ -28,6 +28,21 @@ class Horde_Imap_Client_Stub_Socket extends Horde_Imap_Client_Socket
 {
     public $fetch_results;
 
+    private bool $captureSendCmd = false;
+
+    public ?Horde_Imap_Client_Interaction_Pipeline $capturedPipeline = null;
+
+    protected function _sendCmd($cmd)
+    {
+        if ($this->captureSendCmd) {
+            $this->capturedPipeline = ($cmd instanceof Horde_Imap_Client_Interaction_Command)
+                ? $this->_pipeline($cmd)
+                : $cmd;
+            return $this->capturedPipeline;
+        }
+        return parent::_sendCmd($cmd);
+    }
+
     public function getThreadSort($data)
     {
         return new Horde_Imap_Client_Data_Thread($this->doServerResponse($this->_pipeline(), $data)->data['threadparse'], 'uid');
@@ -93,6 +108,12 @@ class Horde_Imap_Client_Stub_Socket extends Horde_Imap_Client_Socket
     public function fetch($mailbox, $query, array $options = array())
     {
         return $this->fetch_results;
+    }
+
+    public function doVanishedPipeline($modseq, Horde_Imap_Client_Ids $ids) {
+        $this->captureSendCmd = true;
+        $this->_init['capability'] = new Horde_Imap_Client_Data_Capability_Imap();
+        return $this->_vanished($modseq, $ids);
     }
 
 }


### PR DESCRIPTION
**Add chunking to the vanished command.**

Without chunking, the UID FETCH command might exceed the maximum length for an imap command.

fetchCmd (that is also using UID FETCH) already does: https://github.com/bytestream/Imap_Client/blob/33dc825bb4fb0a3fc6c892625404807aee7cd861/lib/Horde/Imap/Client/Socket.php#L3080-L3094

