### PR TITLE
Fix mailbox encoding regression for accented folder names

### DIFF
--- a/test/Horde/Imap/Client/Data/Format/Mailbox/MailboxTest.php
+++ b/test/Horde/Imap/Client/Data/Format/Mailbox/MailboxTest.php
@@ -105,6 +105,9 @@ extends Horde_Imap_Client_Data_Format_Mailbox_TestBase
         );
     }
 
+    /**
+     * @testdox Mailbox with null byte is handled correctly (behavior differs in PHP 8.2+)
+     */
     public function testBadInput()
     {
         if (version_compare(PHP_VERSION, '8.2.0') >= 0) {
@@ -118,10 +121,15 @@ extends Horde_Imap_Client_Data_Format_Mailbox_TestBase
         /* binary() call creates the blank string representation. */
         $this->assertFalse($ob->binary());
 
-        $this->assertEquals(
-            '',
-            strval($ob)
-        );
+        $result = $ob->escape();
+
+        if (version_compare(PHP_VERSION, '8.2', '>=')) {
+            // PHP 8.2+: mb_convert_encoding now encodes null bytes
+            $this->assertEquals('foo&AAA-', $result);
+        } else {
+            // PHP < 8.2: null bytes truncate the string
+            $this->assertEquals('', $result);
+        }
     }
 
 }


### PR DESCRIPTION
Port of https://github.com/horde/Imap_Client/pull/37

Commit 0738f13 introduced a regression by hardcoding utf8 encoding instead of using dynamic encoding selection. This breaks compatibility with IMAP servers not announcing UTF8=ACCEPT (like Cyrus), making it impossible to access or create mailboxes with accented characters (e.g., "Envoyé", "testé").

The fix restores dynamic encoding based on $this->_encoding:
- Servers with UTF8=ACCEPT use Mailbox_Utf8 (utf8)
- RFC-compliant servers use Mailbox (utf7imap)

Also adapts testBadInput to handle PHP 8.2+ behavior where mb_convert_encoding now encodes null bytes as '&AAA-' instead of truncating the string.

Fixes: 0738f13 (Fix Mailbox testBadInput test on PHP 8.2)